### PR TITLE
Fixed errors in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,15 @@ You'll need to create a new instance of `Elevator`, and pass it some audio eleme
 // Elevator script included on the page, already.
 
 window.onload = function() {
-  var elevator = new Elevator({
+  new Elevator({
     mainAudio: '/src/to/audio.mp3',
     endAudio: '/src/to/end-audio.mp3'
   });
 }
 
-// You can run the elevator, by calling.
-elevator.elevate();
+// You can run the elevator, by calling. Caution, Elevator
+// with a capital E
+Elevator.elevate();
 </script>
 ```
 
@@ -36,7 +37,7 @@ You can also add an "element" option, clicking this element will invoke the "Scr
 // Elevator script included on the page, already.
 
 window.onload = function() {
-  var elevator = new Elevator({
+  new Elevator({
     element: document.querySelector('.elevator-button'),
     mainAudio: '/src/to/audio.mp3',
     endAudio: '/src/to/end-audio.mp3'
@@ -53,7 +54,7 @@ If you're really serious (boring), you don't have to use audio... and can also s
 // Elevator script included on the page, already.
 
 window.onload = function() {
-  var elevator = new Elevator({
+  new Elevator({
     element: document.querySelector('.elevator-button'),
     duration: 1000 // milliseconds
   });


### PR DESCRIPTION
The example given in the README to trigger the elevator from Javascript was not working. 

In :
```javascript
var elevator = new Elevator ({ ... });
```
the elevator variable is an object resolved as `main {}` by Chrome. Thus calling `elevator.elevate ()` raises an error because `elevator` doesn't contains such a function. This is working :
```javascript
Elevator.elevate ();
```