### PR TITLE
Barebones support for IE9 and below

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# EditorConfig
+# http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/elevator.js
+++ b/elevator.js
@@ -38,7 +38,7 @@ var Elevator = function(options) {
         if ( t < 1 ) return c / 2 * t * t + b;
         t--;
         return -c / 2 * ( t * ( t -2 ) - 1 ) + b;
-    };
+    }
 
     function extendParameters(options, defaults){
         for( var option in defaults ){
@@ -70,7 +70,7 @@ var Elevator = function(options) {
         } else {
             animationFinished();
         }
-   };
+     }
 
 //            ELEVATE!
 //              /
@@ -105,6 +105,10 @@ var Elevator = function(options) {
         if( mainAudio ) {
             mainAudio.play();
         }
+    };
+
+    function browserMeetsRequirements() {
+        return window.requestAnimationFrame && window.Audio && window.addEventListener;
     }
 
     function resetPositions() {
@@ -147,11 +151,19 @@ var Elevator = function(options) {
 
     //@TODO: Does this need tap bindings too?
     function bindElevateToElement( element ) {
-        element.addEventListener('click', that.elevate, false);
+        if( element.addEventListener ) {
+            element.addEventListener('click', that.elevate, false);
+        } else {
+            element.attachEvent('onclick', function() {
+                document.documentElement.scrollTop = 0;
+                document.body.scrollTop = 0;
+                window.scroll(0, 0);
+            });
+        }
+
     }
 
     function init( _options ) {
-
         // Bind to element click event, if need be.
         body = document.body;
 
@@ -169,17 +181,17 @@ var Elevator = function(options) {
             bindElevateToElement( _options.element );
         }
 
+        // Take the stairs instead
+        if( !browserMeetsRequirements() ) {
+            return;
+        }
+
         if( _options.duration ) {
             customDuration = true;
             duration = _options.duration;
         }
 
         window.addEventListener('blur', onWindowBlur, false);
-
-        // If the browser doesn't support audio, stop here!
-        if ( !window.Audio ) {
-            return;
-        }
 
         if( _options.mainAudio ) {
             mainAudio = new Audio( _options.mainAudio );


### PR DESCRIPTION
Fixes #85.

I promised to patch it - took way too long but I did it :)

`window.requestAnimationFrame` is not available on IE9 and below, while `window.audio` and `window.addEventListener` are not available on IE8 and below. This patches them so they still "scroll to top", but with no bells and whistles.

I also added an `.editorconfig` following your 4 spaces rule. My Sublime was acting weird and forcing 2 spaces on save, but this ends up as a nice addition.

_PS: I didn't uglify the file as I'm not sure how you want it to be done. On that note, I think we should wrap the whole thing in an IIFE._