### PR TITLE
Custom scroll target

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,24 @@ window.onload = function() {
 </script>
 ```
 
+If you don't want to scroll to the top, a custom target can be specified by adding a "targetElement" option:
+```html
+<div class="elevator-button">Take the elevator to the target</div>
+
+<script>
+// Elevator script included on the page, already.
+
+window.onload = function() {
+  var elevator = new Elevator({
+    element: document.querySelector('.elevator-button'),
+	targetElement: document.querySelector('#elevator-target'),
+    mainAudio: '/src/to/audio.mp3',
+    endAudio: '/src/to/end-audio.mp3'
+  });
+}
+</script>
+```
+
 If you're really serious (boring), you don't have to use audio... and can also set a fixed time to scroll to the top
 ```html
 <div class="elevator-button">Back to Top</div>

--- a/elevator.js
+++ b/elevator.js
@@ -22,6 +22,7 @@ var Elevator = function(options) {
     var customDuration = false;
     var startTime = null;
     var startPosition = null;
+	var endPosition = 0;
     var elevating = false;
 
     var mainAudio;
@@ -50,6 +51,15 @@ var Elevator = function(options) {
         }
         return options;
     }
+	
+	function getVerticalOffset(element) {
+		var verticalOffset = 0;
+		while( element ){
+			verticalOffset += element.offsetTop || 0;
+			element = element.offsetParent;
+		}		
+		return verticalOffset;
+	}
 
     /**
      * Main
@@ -62,7 +72,7 @@ var Elevator = function(options) {
         }
 
         var timeSoFar = time - startTime;
-        var easedPosition = easeInOutQuad(timeSoFar, startPosition, -startPosition, duration);
+        var easedPosition = easeInOutQuad(timeSoFar, startPosition, endPosition-startPosition, duration);
 
         window.scrollTo(0, easedPosition);
 
@@ -146,7 +156,7 @@ var Elevator = function(options) {
                 mainAudio.currentTime = 0;
             }
 
-            window.scrollTo(0, 0);
+            window.scrollTo(0, endPosition);
         }
     }
 
@@ -156,9 +166,9 @@ var Elevator = function(options) {
         } else {
             // Older browsers
             element.attachEvent('onclick', function() {
-                document.documentElement.scrollTop = 0;
-                document.body.scrollTop = 0;
-                window.scroll(0, 0);
+                document.documentElement.scrollTop = endPosition;
+                document.body.scrollTop = endPosition;
+                window.scroll(0, endPosition);
             });
         }
     }
@@ -190,6 +200,10 @@ var Elevator = function(options) {
             customDuration = true;
             duration = _options.duration;
         }
+		
+		if( _options.targetElement ) {
+			endPosition = getVerticalOffset(_options.targetElement);
+		}
 
         window.addEventListener('blur', onWindowBlur, false);
 

--- a/elevator.js
+++ b/elevator.js
@@ -22,7 +22,7 @@ var Elevator = function(options) {
     var customDuration = false;
     var startTime = null;
     var startPosition = null;
-	var endPosition = 0;
+    var endPosition = 0;
     var elevating = false;
 
     var mainAudio;
@@ -51,15 +51,15 @@ var Elevator = function(options) {
         }
         return options;
     }
-	
-	function getVerticalOffset(element) {
-		var verticalOffset = 0;
-		while( element ){
-			verticalOffset += element.offsetTop || 0;
-			element = element.offsetParent;
-		}		
-		return verticalOffset;
-	}
+
+    function getVerticalOffset(element) {
+        var verticalOffset = 0;
+        while( element ){
+            verticalOffset += element.offsetTop || 0;
+            element = element.offsetParent;
+        }
+        return verticalOffset;
+    }
 
     /**
      * Main
@@ -200,10 +200,10 @@ var Elevator = function(options) {
             customDuration = true;
             duration = _options.duration;
         }
-		
-		if( _options.targetElement ) {
-			endPosition = getVerticalOffset(_options.targetElement);
-		}
+
+        if( _options.targetElement ) {
+            endPosition = getVerticalOffset(_options.targetElement);
+        }
 
         window.addEventListener('blur', onWindowBlur, false);
 


### PR DESCRIPTION
I have extended the functionality to support scrolling to arbitrary elements, instead of just the top.

It is fully backwards compatible, if a target is not specified, it will fall back to scrolling to the top as before. (However, maybe it does invalidate the 'a "back to top" button' tagline :) )