### PR TITLE
[bugfix] move target position calculation from init to elevation-time

### DIFF
--- a/elevator.js
+++ b/elevator.js
@@ -23,6 +23,7 @@ var Elevator = function(options) {
     var startTime = null;
     var startPosition = null;
     var endPosition = 0;
+    var targetElement = null;
     var elevating = false;
 
     var startCallback;
@@ -106,6 +107,7 @@ var Elevator = function(options) {
 
         elevating = true;
         startPosition = (document.documentElement.scrollTop || body.scrollTop);
+        updateEndPosition();
 
         // No custom duration set, so we travel at pixels per millisecond. (0.75px per ms)
         if( !customDuration ) {
@@ -132,6 +134,12 @@ var Elevator = function(options) {
         startTime = null;
         startPosition = null;
         elevating = false;
+    }
+
+    function updateEndPosition() {
+        if(targetElement){
+            endPosition = getVerticalOffset(targetElement);            
+        }
     }
 
     function animationFinished() {
@@ -166,6 +174,7 @@ var Elevator = function(options) {
                 mainAudio.currentTime = 0;
             }
 
+            updateEndPosition();            
             window.scrollTo(0, endPosition);
         }
     }
@@ -176,6 +185,7 @@ var Elevator = function(options) {
         } else {
             // Older browsers
             element.attachEvent('onclick', function() {
+                updateEndPosition();
                 document.documentElement.scrollTop = endPosition;
                 document.body.scrollTop = endPosition;
                 window.scroll(0, endPosition);
@@ -214,7 +224,7 @@ var Elevator = function(options) {
         }
 
         if( _options.targetElement ) {
-            endPosition = getVerticalOffset(_options.targetElement);
+            targetElement = _options.targetElement;
         }
 
         window.addEventListener('blur', onWindowBlur, false);

--- a/elevator.js
+++ b/elevator.js
@@ -111,7 +111,7 @@ var Elevator = function(options) {
 
         // No custom duration set, so we travel at pixels per millisecond. (0.75px per ms)
         if( !customDuration ) {
-            duration = (startPosition * 1.5);
+            duration = ( Math.abs(endPosition - startPosition) * 1.5);
         }
 
         requestAnimationFrame( animateLoop );


### PR DESCRIPTION
I noticed an incorrect edge-case concerning my earlier contribution of [custom scroll targets](https://github.com/tholman/elevator.js/commit/492e58206794995308d529fe057d64a0ee16daed#diff-11ecc206210399fabd9fa6f901e894bf): the `endPosition` for the scrolling was calculated inside `init`, which could potentially lead to incorrect scroll positions if there are any DOM reflows between initialization and actual elevating.

As a fix, I introduce an `updateEndPosition` function which is called once before the elevate or any immediate scroll actions.

As a necessary by-product, inside init, targetElement (a new top-level variable) is saved instead of endPosition. No changes in the interface however.

Additionally, the default duration calculation was not updated to consider the differing end positions, this is also amended by this PR.